### PR TITLE
embargos are expected to be indexed as dateable

### DIFF
--- a/app/models/datastreams/dca_admin.rb
+++ b/app/models/datastreams/dca_admin.rb
@@ -8,7 +8,7 @@ class DcaAdmin < ActiveFedora::OmDatastream
     t.comment namespace_prefix: "ac", index_as: :stored_searchable
     t.retentionPeriod index_as: :stored_searchable
     t.displays index_as: [:stored_sortable, :symbol]
-    t.embargo index_as: :stored_searchable
+    t.embargo index_as: :dateable
     t.status index_as: :stored_searchable
     t.startDate index_as: :stored_searchable
     t.expDate index_as: :stored_searchable

--- a/spec/models/dca_admin_spec.rb
+++ b/spec/models/dca_admin_spec.rb
@@ -54,4 +54,10 @@ describe DcaAdmin do
     expect(subject.batch_id).to eq ['1', '2', '3']
   end
 
+  it "should index an embargo date as a date" do
+    subject.embargo='2023-06-12'
+    expect(subject.to_solr).to eq(
+      "embargo_dtsim" =>['2023-06-12T00:00:00Z'])
+  end
+
 end


### PR DESCRIPTION
When we enforce embargos we're expecting them as being stored as :dateable by MIRA.
