### PR TITLE
support preview url for stage and prod dl/fedora

### DIFF
--- a/app/models/concerns/tufts/solr_document.rb
+++ b/app/models/concerns/tufts/solr_document.rb
@@ -34,13 +34,26 @@ module Tufts::SolrDocument
   end
 
   def preview_fedora_path
-    Settings.preview_fedora_url + "/objects/#{id}"
+    if published?
+      fedora_url = Settings.preview_fedora_prod_url
+    else
+      fedora_url = Settings.preview_fedora_stage_url
+    end
+
+    fedora_url + "/objects/#{id}"
   end
 
   def preview_dl_path
     return nil if template?
+
+    if published?
+      dl_url = Settings.preview_dl_prod_url
+    else
+      dl_url = Settings.preview_dl_stage_url
+    end
+
     if self['displays_ssim'].blank? || self['displays_ssim'] == [''] || self['displays_ssim'].include?('dl')
-      Settings.preview_dl_url + "/catalog/#{id}"
+      dl_url + "/catalog/#{id}"
     else
       return nil
     end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -10,8 +10,21 @@ describe SolrDocument do
   end
 
   describe "#preview_fedora_path" do
-    it "should always have link to fedora object" do
+      before { subject['edited_at_dtsi'] = '2014-06-12T00:00:00Z', subject['published_at_dtsi'] = '2014-06-11T00:00:00Z' }
+    it "should always have link to a fedora stage object when there is a pending publish" do
       url = 'http://localhost:8983/fedora/objects/tufts:7'
+      subject['displays_ssim'] = nil
+      expect(subject.preview_fedora_path).to eq url
+      subject['displays_ssim'] = ['dl']
+      expect(subject.preview_fedora_path).to eq url
+      subject['displays_ssim'] = ['tufts']
+      expect(subject.preview_fedora_path).to eq url
+    end
+
+    it "should always have link to a fedora prod object when it has been published" do
+      subject['edited_at_dtsi'] = '2014-06-12T00:00:00Z'
+      subject['published_at_dtsi'] = '2014-06-12T00:00:00Z'
+      url = 'http://localhost.prod.edu:8983/fedora/objects/tufts:7'
       subject['displays_ssim'] = nil
       expect(subject.preview_fedora_path).to eq url
       subject['displays_ssim'] = ['dl']
@@ -22,10 +35,19 @@ describe SolrDocument do
   end
 
   describe "#preview_dl_path" do
+    before { subject['edited_at_dtsi'] = '2014-06-12T00:00:00Z', subject['published_at_dtsi'] = '2014-06-11T00:00:00Z' }
     let(:url) { 'http://dev-dl.lib.tufts.edu/catalog/tufts:7' }
     describe "when displays is 'dl'" do
       before { subject['displays_ssim'] = ['dl'] }
       it "has a link to the fedora object" do
+        expect(subject.preview_dl_path).to eq url
+      end
+    end
+    describe "when it has been published" do
+      it "should have a link to the fedora object in production" do
+        url = 'http://dl.tufts.edu/catalog/tufts:7'
+        subject['edited_at_dtsi'] = '2014-06-12T00:00:00Z'
+        subject['published_at_dtsi'] = '2014-06-12T00:00:00Z'
         expect(subject.preview_dl_path).to eq url
       end
     end

--- a/spec/test_app_templates/application.yml
+++ b/spec/test_app_templates/application.yml
@@ -10,15 +10,17 @@ defaults: &defaults
   object_store_base: 'data01/tufts'
   object_store_dca: 'central/dca'
   object_store_tisch: 'sas'
-  preview_fedora_url: 'http://hydraadmin-dev.uit.tufts.edu:8080/fedora'
-  preview_dl_url: 'http://dev-dl.lib.tufts.edu'
+  preview_fedora_prod_url: 'http://hydraadmin-dev.uit.tufts.edu:8080/fedora'
+  preview_fedora_stage_url: 'http:/repository01.lib.tufts.edu:8080/fedora'
+  preview_dl_prod_url: 'http://dl.tufts.edu'
+  preview_dl_stage_url: 'http://dev-dl.lib.tufts.edu'
 development:
   <<: *defaults
   neat_setting: 800
   object_store_root: "<%=Rails.root%>/tmp/local_object_store"
   processing_url: "SKIP"
   repository_url: "http://localhost:8983/"
-  preview_fedora_url: 'http://localhost:8983/fedora'
+  preview_fedora_stage_url: 'http://localhost:8983/fedora'
 tdldev:
   <<: *defaults
   object_store_root: "/tdr/dcadata02/tufts/central/dca/fake_bucket"
@@ -34,7 +36,8 @@ test:
   object_store_root: "<%= File.expand_path("../fixtures/local_object_store", Rails.root) %>"
   processing_url: "SKIP"
   repository_url: "http://stage-repository01.lib.tufts.edu:8080"
-  preview_fedora_url: 'http://localhost:8983/fedora'
+  preview_fedora_stage_url: 'http://localhost:8983/fedora'
+  preview_fedora_prod_url: 'http://localhost.prod.edu:8983/fedora'
 production:
   <<: *defaults
   tdl_feedback_address: "deborah.kaplan@tufts.edu"


### PR DESCRIPTION
It was confusing to people when objects were published the preview links would point to stage, so we added separate preview fedora and dl links for stage and production.