### PR TITLE
Nowhere

### DIFF
--- a/app/models/concerns/with_valid_displays.rb
+++ b/app/models/concerns/with_valid_displays.rb
@@ -9,7 +9,7 @@ module WithValidDisplays
 
     def displays_valid
       return unless displays.present?
-      unless displays.all? {|d| %w(dl tisch perseus elections dark trove).include? d }
+      unless displays.all? {|d| %w(dl tisch perseus elections dark trove nowhere).include? d }
         errors.add(:displays, "must be in the list")
       end
     end

--- a/spec/models/tufts_base_spec.rb
+++ b/spec/models/tufts_base_spec.rb
@@ -97,6 +97,8 @@ describe TuftsBase do
       expect(subject).to be_valid
       subject.displays = ['trove']
       expect(subject).to be_valid
+      subject.displays = ['nowhere']
+      expect(subject).to be_valid
       subject.displays = ['fake']
       expect(subject).to_not be_valid
     end


### PR DESCRIPTION
Adds nowhere as a valid displays. We have some items in the repository that realistically have no destination at the moment.  we don't want the validation of
requiring a displays attribute but we need a way to honestly assess these objects currently we're just picking an unused attribute.