### PR TITLE
Elections

### DIFF
--- a/app/models/tufts_voting_record.rb
+++ b/app/models/tufts_voting_record.rb
@@ -1,0 +1,9 @@
+class TuftsVotingRecord < TuftsBase
+
+  has_file_datastream 'RECORD-XML', control_group: 'E', original: true
+
+  def self.to_class_uri
+    'info:fedora/cm:VotingRecord'
+  end
+
+end

--- a/spec/models/tufts_voting_record_spec.rb
+++ b/spec/models/tufts_voting_record_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe TuftsVotingRecord do
+
+  it "should have an original_file_datastreams" do
+    expect(TuftsVotingRecord.original_file_datastreams).to eq ['RECORD-XML']
+  end
+
+  describe "to_class_uri" do
+    subject {TuftsVotingRecord}
+    it "has sets the class_uri" do
+      expect(subject.to_class_uri).to eq 'info:fedora/cm:VotingRecord'
+    end
+  end
+
+end


### PR DESCRIPTION
@mhbussey Here's the pull request for elections we talked about earlier.  I'll make a request against MIRA with the modifications to ingest these.  

There is one change here, if you look at old fixture objects RECORD-XML is an inline XML datastream.  This is different from how we currently manage any other object type so we're in the process of migrating the RECORD-XML stream to be E like all our other objects.  