### PR TITLE
Formatted date

### DIFF
--- a/app/models/concerns/indexing.rb
+++ b/app/models/concerns/indexing.rb
@@ -310,7 +310,7 @@ module Indexing
       self.date_created.each do |date_created|
         # we're storing BCE dates as -0462 using ISO-6801 standard but we want to retrieve them for display formatted for the screen
         if date_created.start_with? '-'
-         date_created = date_created.sub(/^[0\-]*/,"") + " BCE"
+         date_created = "#{date_created.sub(/^[0\-]*/,'')} BCE"
         end
 
         Solrizer.insert_field(solr_doc, 'date_created_formatted', "#{date_created}", :stored_searchable) #tesim

--- a/app/models/concerns/indexing.rb
+++ b/app/models/concerns/indexing.rb
@@ -7,6 +7,7 @@ module Indexing
   def to_solr(solr_doc=Hash.new)
     super.tap do |solr_doc|
       create_facets solr_doc
+      create_formatted_fields solr_doc
       index_sort_fields solr_doc
     end
   end
@@ -302,6 +303,17 @@ module Indexing
         models.each do |model|
           insert_object_type(solr_doc, model)
         end 
+      end
+    end
+
+    def create_formatted_fields(solr_doc)
+      self.date_created.each do |date_created|
+        # we're storing BCE dates as -0462 using ISO-6801 standard but we want to retrieve them for display formatted for the screen
+        if date_created.start_with? '-'
+         date_created = date_created.sub(/^[0\-]*/,"") + " BCE"
+        end
+
+        Solrizer.insert_field(solr_doc, 'date_created_formatted', "#{date_created}", :stored_searchable) #tesim
       end
     end
 

--- a/spec/models/tufts_image_spec.rb
+++ b/spec/models/tufts_image_spec.rb
@@ -88,6 +88,17 @@ describe TuftsImage do
         expect(subject[:id]).to eq 'tufts:1'
         expect(subject['title_tesim']).to eq ['Foo']
       end
+
+      it "should create a solr document with appropriately formatted BCE date created" do
+        image.date_created = ['-0462']
+        expect(subject['date_created_formatted_tesim']).to eq ['462 BCE']
+      end
+
+      it "should create a solr document with an appropriately CE date" do
+        image.date_created = ['1963']
+        expect(subject['date_created_formatted_tesim']).to eq ['1963']
+      end
+
     end
 
   end

--- a/spec/models/tufts_image_text_spec.rb
+++ b/spec/models/tufts_image_text_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe TuftsImageText do
-  
-end


### PR DESCRIPTION
@jcoyne this adds a formatted date created field for display in trove, and removes tufts_image_text spec which was empty but the model was already removed so it didn't make sense to leave it.