### PR TITLE
When publishing a file, publish all of the datastreams

### DIFF
--- a/app/models/concerns/base_model.rb
+++ b/app/models/concerns/base_model.rb
@@ -47,7 +47,7 @@ module BaseModel
       if respond_to?(:content_will_update) && content_will_update
         self.audit(working_user, "Content updated: #{content_will_update}")
         self.content_will_update = nil
-      elsif metadata_streams.any? { |ds| ds.changed? }
+      elsif metadata_streams.any? { |ds| ds.changed? } && !publishing
         self.audit(working_user, "Metadata updated #{metadata_streams.select { |ds| ds.changed? }.map{ |ds| ds.dsid}.join(', ')}")
       end
 

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -15,7 +15,7 @@ module Publishable
   end
 
   def publish!(user_id = nil)
-    user = user_id ? User.find(user_id) : 'No user'
+    user = User.find(user_id) if user_id
     create_published_version!(user)
   end
 

--- a/spec/models/concerns/publishable_spec.rb
+++ b/spec/models/concerns/publishable_spec.rb
@@ -87,9 +87,6 @@ describe Publishable do
     it 'adds an entry to the audit log' do
       expect(obj).to receive(:audit).with(instance_of(User), 'Pushed to production').once
 
-      # This needs to be happen a number of times because of the multiple object updates in #publish!
-      expect(obj).to receive(:audit).with(instance_of(User), 'Metadata updated DCA-ADMIN').once
-
       obj.publish!(user.id)
     end
 

--- a/spec/models/concerns/publishable_spec.rb
+++ b/spec/models/concerns/publishable_spec.rb
@@ -42,75 +42,73 @@ describe Publishable do
   describe '#publish!' do
     let(:user) { FactoryGirl.create(:user) }
 
-    before do
-      @obj = TuftsImage.create(title: 'My title', displays: ['dl'])
+    let(:obj) do
+      TuftsImage.create(title: 'My title', displays: ['dl']).tap do |image|
+        image.datastreams['Thumbnail.png'].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/UA136/thumb_png/UA136.002.DO.02673.thumbnail.png"
+        image.save
+      end
     end
 
     after do
-      @obj.delete if @obj
+      obj.destroy if obj
     end
 
     context "when a published version does not exist" do
-      it "results in a published copy of the draft existing" do
-        published_pid = PidUtils.to_published(@obj.pid)
-        expect(TuftsImage.exists?(published_pid)).to be_falsey
 
-        @obj.publish!
+      let(:published_pid) { PidUtils.to_published(obj.pid) }
 
-        expect(TuftsImage.exists?(published_pid)).to be_truthy
+      it "results in a published copy of the draft" do
+        expect {
+          obj.publish!
+        }.to change { TuftsImage.exists?(published_pid) }.from(false).to(true)
+
+        published_obj = obj.find_published
+        expect(published_obj).to be_published
+        expect(published_obj.title).to eq 'My title'
+        expect(published_obj.displays).to eq ['dl']
+        expect(published_obj.datastreams['Thumbnail.png']).not_to be_new
       end
     end
 
     context "when a published version already exists" do
-      it "destroys the existing published copy" do
-        published_pid = PidUtils.to_published(@obj.pid)
+      let(:published_pid) { PidUtils.to_published(obj.pid) }
+      before { obj.publish! }
 
-        @obj.publish!
-
-        published_obj = double('published')
-        expect(published_obj).to receive(:destroy) { true }
-        expect(TuftsImage).to receive(:find).with(published_pid).once { published_obj }
-
-        @obj.publish!
+      it "replaces the existing published copy" do
+        obj.update_attributes title: 'Edited title'
+        obj.publish!
+        published_obj = obj.find_published
+        expect(published_obj.title).to eq 'Edited title'
       end
 
-      it "results in a published copy of the original" do
-        @obj.publish!
-
-        published_obj = @obj.find_published
-
-        expect(published_obj).to be_published
-        expect(published_obj.title).to eq('My title')
-        expect(published_obj.displays).to eq(['dl'])
-      end
     end
 
 
     it 'adds an entry to the audit log' do
-      expect(@obj).to receive(:audit).with(instance_of(User), 'Pushed to production').once
+      expect(obj).to receive(:audit).with(instance_of(User), 'Pushed to production').once
 
       # This needs to be happen a number of times because of the multiple object updates in #publish!
-      expect(@obj).to receive(:audit).with(instance_of(User), 'Metadata updated DCA-ADMIN').once
+      expect(obj).to receive(:audit).with(instance_of(User), 'Metadata updated DCA-ADMIN').once
 
-      @obj.publish!(user.id)
+      obj.publish!(user.id)
     end
 
     it 'results in the image being published' do
       skip "this test randomly fails"
 
-      expect(@obj.published_at).to eq(nil)
+      expect(obj.published_at).to eq(nil)
 
-      @obj.publish!
-      @obj.reload
-      expect(@obj.published?).to be_truthy
+      obj.publish!
+      obj.reload
+      expect(obj.published?).to be_truthy
     end
 
     it 'only updates the published_at time when actually published' do
-      expect(@obj.published_at).to eq nil
+      expect(obj.published_at).to eq nil
 
-      @obj.publish!(user.id)
+      obj.publish!(user.id)
 
-      expect(@obj.published_at).to_not be_nil
+      expect(obj.published_at).to_not be_nil
     end
   end
 


### PR DESCRIPTION
Fixes curationexperts/mira#402