### PR TITLE
Turned off versioning for external datastreams

### DIFF
--- a/app/models/tufts_audio.rb
+++ b/app/models/tufts_audio.rb
@@ -1,7 +1,7 @@
 class TuftsAudio < TuftsBase
-  has_file_datastream 'ARCHIVAL_WAV', control_group: 'E', default: true
-  has_file_datastream 'ARCHIVAL_XML', control_group: 'E'
-  has_file_datastream 'ACCESS_MP3', control_group: 'E'
+  has_file_datastream 'ARCHIVAL_WAV', control_group: 'E', versionable: false, default: true
+  has_file_datastream 'ARCHIVAL_XML', control_group: 'E', versionable: false
+  has_file_datastream 'ACCESS_MP3', control_group: 'E', versionable: false
 
   def create_derivatives
     access_path = LocalPathService.new(self, 'ACCESS_MP3', 'mp3')

--- a/app/models/tufts_ead.rb
+++ b/app/models/tufts_ead.rb
@@ -1,5 +1,5 @@
 class TuftsEAD < TuftsBase
-  has_file_datastream 'Archival.xml', control_group: 'E', default: true
+  has_file_datastream 'Archival.xml', control_group: 'E', versionable: false, default: true
 
   def self.to_class_uri
     'info:fedora/cm:Text.EAD'

--- a/app/models/tufts_image.rb
+++ b/app/models/tufts_image.rb
@@ -1,8 +1,9 @@
 class TuftsImage < TuftsBase
-  has_file_datastream 'Thumbnail.png', control_group: 'E'
-  has_file_datastream 'Archival.tif', control_group: 'E', default: true
-  has_file_datastream 'Advanced.jpg', control_group: 'E'
-  has_file_datastream 'Basic.jpg', control_group: 'E'
+  has_file_datastream 'Thumbnail.png', control_group: 'E', versionable: false
+  has_file_datastream 'Archival.tif', control_group: 'E', versionable: false, default: true
+  has_file_datastream 'Advanced.jpg', control_group: 'E', versionable: false
+  has_file_datastream 'Basic.jpg', control_group: 'E', versionable: false
+
   include CollectionMember
 
   def self.default_content_ds

--- a/app/models/tufts_pdf.rb
+++ b/app/models/tufts_pdf.rb
@@ -4,8 +4,8 @@ class TuftsPdf < TuftsBase
   PDF_CONTENT_DS = 'Archival.pdf'
   TRANSFER_BINARY_DS = 'Transfer.binary'
 
-  has_file_datastream PDF_CONTENT_DS, control_group: 'E', default: true
-  has_file_datastream TRANSFER_BINARY_DS, control_group: 'E'
+  has_file_datastream PDF_CONTENT_DS, control_group: 'E', versionable: false, default: true
+  has_file_datastream TRANSFER_BINARY_DS, control_group: 'E', versionable: false
 
   include WithPageImages
 

--- a/app/models/tufts_rcr.rb
+++ b/app/models/tufts_rcr.rb
@@ -1,5 +1,5 @@
 class TuftsRCR < TuftsBase
-  has_file_datastream 'RCR-CONTENT', control_group: 'E', default: true
+  has_file_datastream 'RCR-CONTENT', control_group: 'E', versionable: false, default: true
 
   def self.to_class_uri
     'info:fedora/cm:Text.RCR'

--- a/app/models/tufts_tei.rb
+++ b/app/models/tufts_tei.rb
@@ -1,5 +1,5 @@
 class TuftsTEI < TuftsBase
-  has_file_datastream "Archival.xml", control_group: 'E', default: true
+  has_file_datastream "Archival.xml", control_group: 'E', versionable: false, default: true
 
   def self.to_class_uri
     'info:fedora/cm:Text.TEI'

--- a/app/models/tufts_video.rb
+++ b/app/models/tufts_video.rb
@@ -1,10 +1,10 @@
 class TuftsVideo < TuftsBase
 
-  has_file_datastream 'Archival.video', control_group: 'E', default: true
-  has_file_datastream 'ARCHIVAL_XML', control_group: 'E'
-  has_file_datastream 'Thumbnail.png', control_group: 'E'
-  has_file_datastream 'Access.webm', control_group: 'E'
-  has_file_datastream 'Access.mp4', control_group: 'E'
+  has_file_datastream 'Archival.video', control_group: 'E', versionable: false, default: true
+  has_file_datastream 'ARCHIVAL_XML', control_group: 'E', versionable: false
+  has_file_datastream 'Thumbnail.png', control_group: 'E', versionable: false
+  has_file_datastream 'Access.webm', control_group: 'E', versionable: false
+  has_file_datastream 'Access.mp4', control_group: 'E', versionable: false
 
   # @param [String] dsid Datastream id
   # @param [String] type the content type to test

--- a/app/models/tufts_voting_record.rb
+++ b/app/models/tufts_voting_record.rb
@@ -1,5 +1,5 @@
 class TuftsVotingRecord < TuftsBase
-  has_file_datastream 'RECORD-XML', control_group: 'E', default: true
+  has_file_datastream 'RECORD-XML', control_group: 'E', versionable: false, default: true
 
   def self.to_class_uri
     'info:fedora/cm:VotingRecord'


### PR DESCRIPTION
Using versioning and checksum verification when you have an external
datastream will cause checksum versification errors when the file
content at the dsLocation changes.  This is because the verifier
validates checksums for all versions, even though only the most recent
one will be valid.